### PR TITLE
Added option to disable signup

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -69,10 +69,14 @@ impl IntoResponse for Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-pub fn get_router(pool: SqlitePool) -> Router {
-    Router::new()
-        .route("/users/create", post(register))
-        .merge(
+pub fn get_router(pool: SqlitePool, enable_register: bool) -> Router {
+    let router = if enable_register {
+        Router::new()
+            .route("/users/create", post(register))
+    } else {
+        Router::new()
+    };
+    router.merge(
             Router::new()
                 .route("/users/auth", get(check_authorized))
                 .route("/syncs/progress", put(put_progress))

--- a/src/api.rs
+++ b/src/api.rs
@@ -405,7 +405,7 @@ mod tests {
 
     #[sqlx::test]
     async fn test_register(pool: SqlitePool) {
-        let app = get_router(pool);
+        let app = get_router(pool, true);
 
         for username in &vec!["username1", "username2"] {
             let response = run_req(app.clone(), create_user_req(username, "password")).await;
@@ -425,7 +425,7 @@ mod tests {
 
     #[sqlx::test]
     async fn test_check_auth(pool: SqlitePool) {
-        let app = get_router(pool);
+        let app = get_router(pool, true);
 
         let response = run_req(app.clone(), check_authorized_req("username", "password")).await;
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
@@ -448,7 +448,7 @@ mod tests {
 
     #[sqlx::test]
     async fn test_sync_progress(pool: SqlitePool) {
-        let app = get_router(pool);
+        let app = get_router(pool, true);
 
         let _ = run_req(app.clone(), create_user_req("username", "password")).await;
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -71,12 +71,12 @@ type Result<T> = std::result::Result<T, Error>;
 
 pub fn get_router(pool: SqlitePool, enable_register: bool) -> Router {
     let router = if enable_register {
-        Router::new()
-            .route("/users/create", post(register))
+        Router::new().route("/users/create", post(register))
     } else {
         Router::new()
     };
-    router.merge(
+    router
+        .merge(
             Router::new()
                 .route("/users/auth", get(check_authorized))
                 .route("/syncs/progress", put(put_progress))

--- a/src/args.rs
+++ b/src/args.rs
@@ -11,6 +11,9 @@ pub struct Args {
     /// Database path
     #[clap(short, long)]
     pub db: PathBuf,
+    /// enable register
+    #[clap(short, long)]
+    pub enable_register: bool,
 
     #[clap(flatten)]
     pub verbose: Verbosity,

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn try_main() -> Result<()> {
 
     let pool = get_db_pool(&args.db).await?;
 
-    let app = api::get_router(pool);
+    let app = api::get_router(pool, args.enable_register);
 
     axum::Server::bind(&args.address)
         .serve(app.into_make_service())


### PR DESCRIPTION
When self-hosting this accessible to the public internet, having a publicly accessible signup endpoint poses a risk for abuse. This PR
 * disables registration
 * adds a `--enable-register` flag to enable registration

Let me know what you think 😊